### PR TITLE
fix support for manifest without start_url

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (options) {
     .then(function(manifestJson) {
       debug('manifestJson', manifestJson);
       var name = manifestJson.name || manifestJson.short_name;
-      var start_url = appUrl + manifestJson.start_url ;
+      var start_url = appUrl + (manifestJson.start_url || '');
       var appData = {
         appUrl: start_url
       };


### PR DESCRIPTION
If `"start_url"` is not defined in `manifest.json`, `var start_url` (line 19) will be assigned `https://example.pwa/undefined` instead of `https://example.pwa`. This fix solves this issue.

Note: I couldn't find in the spec if "start_url" is a required property, nor could I find a `manifest.json` validator. If the property is in fact required pwaify should through an error instead of falling back to an empty string.