### PR TITLE
 Added support for CLI option --manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install -g pwaify
 ```
 pwaify https://airhorner.com
 pwaify https://voice-memos.appspot.com/ --platforms=darwin --icon chrome-touch-icon-384x384.icns
+pwaify https://m.weibo.cn --platforms=darwin --manifest=https://m.weibo.cn/static/pwa/manifest.json
 ```
 
 (Might require `sudo` at the moment if you get `pref.json` error).

--- a/bin/pwaify
+++ b/bin/pwaify
@@ -8,6 +8,7 @@ const cli = meow(`
     Options
       --platforms Platforms to build the app.
       --icon App Icon.
+      --manifest Manifest.json url.
 
     Examples
       $ pwaify https://airhorner.com --platforms=darwin
@@ -17,5 +18,6 @@ require('../index')({
   appUrl: cli.input[0],
   platforms: cli.flags.platforms || 'all',
   path: cli.flags.path || '.',
-  icon: cli.flags.icon
+  icon: cli.flags.icon,
+  manifestUrl: cli.flags.manifest
 });

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = function (options) {
   debug('options', options);
   const appUrl = options.appUrl;
   const appPath = options.path;
-
-  return manifest.fetchManifestDetails(appUrl)
+  const manifestUrl = options.manifestUrl;
+  return manifest.fetchManifestDetails(appUrl, manifestUrl)
     .then(function(manifestJson) {
       debug('manifestJson', manifestJson);
       var name = manifestJson.name || manifestJson.short_name;

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -3,8 +3,13 @@ const debug = require('debug')('manifest');
 const Xray = require('x-ray');
 
 module.exports = {
-  fetchManifestDetails: function fetchManifestDetails (appUrl) {
+  fetchManifestDetails: function fetchManifestDetails (appUrl, manifestUrl) {
     return new Promise(function (resolve, reject) {
+      if (manifestUrl) {
+        return resolve({
+          manifestTarget: manifestUrl
+        });
+      }
       var xray = Xray();
       xray(appUrl, 'link[rel=manifest]@href')(function(err, manifestTarget) {
         debug(err, manifestTarget);


### PR DESCRIPTION
Added support for CLI option --manifest.

You can specify the URL of manifest.json directly on the command line with the --manifest option.